### PR TITLE
fix: updates exports to improve import api

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,18 @@
    "description": "Easily and securely inject environment variable secrets—no matter the size—into any JavaScript runtime.",
    "main": "dist/index.js",
    "types": "dist/index.d.ts",
+   "exports": {
+      ".": {
+         "import": "./dist/index.js",
+         "require": "./dist/index.js",
+         "types": "./dist/index.d.ts"
+      },
+      "./no-fs": {
+         "import": "./dist/no-fs.js",
+         "require": "./dist/no-fs.js",
+         "types": "./dist/no-fs.d.ts"
+      }
+   },
    "files": [
       "dist"
    ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,5 @@ import * as secretsFiles from './secrets-files';
 
 export const providers = { doppler };
 
-export default {
-   ...secrets,
-   ...secretsFiles,
-   providers,
-};
+export * as secrets from './secrets';
+export * as secretsFiles from './secrets-files';

--- a/src/no-fs.ts
+++ b/src/no-fs.ts
@@ -1,6 +1,9 @@
 import * as doppler from './providers/doppler';
 import * as secrets from './secrets';
 
+export * from './secrets';
+export const providers = { doppler };
+
 const noFs = {
    ...secrets,
    providers: {
@@ -9,6 +12,3 @@ const noFs = {
 };
 
 export default noFs;
-
-export * from './secrets';
-export const providers = { doppler };

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-   entry: ['src/index.ts'],
+   entry: ['src/index.ts', 'src/no-fs.ts'],
    outDir: 'dist',
    format: ['esm', 'cjs'],
    dts: true,


### PR DESCRIPTION
## Description
Corrects API to make imports more accessible and no longer nested under `default` namespace. Additionally exports the `no-fs` version.